### PR TITLE
fix(client): INFRA-1793 Remove deprecated constant.

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -687,7 +687,7 @@ class ClientBuilder
      */
     private function prependMissingScheme($host)
     {
-        if (!filter_var($host, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED)) {
+        if (!filter_var($host, FILTER_VALIDATE_URL)) {
             $host = 'http://' . $host;
         }
 


### PR DESCRIPTION
## What?
Remove usage of a deprecated constant.

## Why?
This constant generates warnings with PHP 7.3 and leads to Travis failures in dependent projects.

## Testing / Proof
Same as https://github.com/elastic/elasticsearch-php/pull/803

Ping @rayward @lord2800 @bigcommerce/cp-dt @precariouspanther 